### PR TITLE
Changing collection.js to handle new device streams for known hubs / devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/collection.js
+++ b/collection.js
@@ -3,7 +3,15 @@ var url = require('url');
 var util = require('util');
 var rels = require('zetta-rels');
 
-var StatsCollector = module.exports = function() {
+var EXCLUDED_EVENTS = [
+    /^_peer\/.+/, // peer events
+    /^logs$/ // logs topic is emitted for stdout on device transitions
+];
+
+var StatsCollector = module.exports = function(options) {
+  options = options || {};
+  this.includeServerEvents = !!(options.includeServerEvents);
+  
   EventEmitter.call(this);
 };
 util.inherits(StatsCollector, EventEmitter);
@@ -15,45 +23,25 @@ StatsCollector.prototype.collect = function() {
 StatsCollector.prototype._collect = function(runtime) {
   var self = this;
 
+  var peers = [];
   runtime.pubsub.subscribe('_peer/connect', function(ev, msg) {
-    var topic = 'query:collector+' + msg.peer.name + '/where type is not missing';
+    if (peers.indexOf(msg.peer.name) < 0) {
+      msg.peer.subscribe('**');
+      msg.peer.on('zetta-events', function(topic, data) {
+        if (!self.includeServerEvents) {
+          var found = EXCLUDED_EVENTS.some(function(regex) {
+            return regex.test(topic);
+          });
+          
+          if (found) {
+            return;
+          }
+        }
 
-    if (Object.keys(msg.peer.subscriptions).indexOf(encodeURIComponent(topic)) !== -1) {
-      return;
+        self.emit('event', data);
+      });
+      
+      peers.push(msg.peer.name);
     }
-
-    msg.peer.on(topic, function(device) {
-      var links = device.links.filter(function(link) {
-        if (link.rel.indexOf(rels.objectStream) !== -1
-          || link.rel.indexOf(rels.binaryStream) !== -1) {
-          return link;
-        }
-      });
-
-      if (links.length === 0) {
-        return;
-      }
-
-      var topics = links.map(function(link) {
-        var querystring = url.parse(link.href, true);
-        return querystring.query.topic;
-      });
-
-      if (topics.length === 0) {
-        return;
-      }
-
-      topics.forEach(function(topic) {
-        if (Object.keys(msg.peer.subscriptions).indexOf(topic) !== -1) {
-          return;
-        }
-
-        msg.peer.on(topic, function(deviceMessage) {
-          self.emit('event', deviceMessage);
-        });
-        msg.peer.subscribe(topic);
-      });
-    });
-    msg.peer.subscribe(encodeURIComponent(topic));
   });
 };

--- a/collection.js
+++ b/collection.js
@@ -2,7 +2,6 @@ var EventEmitter = require('events').EventEmitter;
 var url = require('url');
 var util = require('util');
 var rels = require('zetta-rels');
-var uuid = require('node-uuid');
 
 var StatsCollector = module.exports = function() {
   EventEmitter.call(this);
@@ -17,9 +16,9 @@ StatsCollector.prototype._collect = function(runtime) {
   var self = this;
 
   runtime.pubsub.subscribe('_peer/connect', function(ev, msg) {
-    var topic = 'query:' + uuid.v4() + '/where type is not missing';
+    var topic = 'query:collector+' + msg.peer.name + '/where type is not missing';
 
-    if (Object.keys(msg.peer.subscriptions).indexOf(topic) !== -1) {
+    if (Object.keys(msg.peer.subscriptions).indexOf(encodeURIComponent(topic)) !== -1) {
       return;
     }
 

--- a/collection.js
+++ b/collection.js
@@ -8,6 +8,14 @@ var EXCLUDED_EVENTS = [
     /^logs$/ // logs topic is emitted for stdout on device transitions
 ];
 
+var FILTERED_HEADERS = [
+  'connection',
+  'upgrade',
+  'sec-websocket-key',
+  'authorization',
+  'sec-websocket-version'
+];
+
 var StatsCollector = module.exports = function(options) {
   options = options || {};
   this.includeServerEvents = !!(options.includeServerEvents);
@@ -38,7 +46,33 @@ StatsCollector.prototype._collect = function(runtime) {
           }
         }
 
-        self.emit('event', data);
+
+        var split = data.topic.split('/');
+
+        // Only publish device data events that conform to {type}/{id}/{stream}
+        if (split.length === 3) {
+          var formatedData = {
+            name: 'devicedata.' + split[0] + '.' + split[2],
+            timestamp: data.timestamp,
+            value: data.data,
+            tags: {
+              hub: msg.peer.name,
+              device: split[1],
+              deviceType: split[1],
+              stream: split[2]
+            }
+          };
+
+          Object.keys(msg.peer.ws.upgradeReq.headers).forEach(function(header) {
+            if (FILTERED_HEADERS.indexOf(header) === -1) {
+              formatedData.tags['req-header-' + header] = msg.peer.ws.upgradeReq.headers[header];
+            }
+          });
+          
+          self.emit('event', formatedData);
+        } else {
+          return;
+        }
       });
       
       peers.push(msg.peer.name);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Subscribe to all devices streams and pipe to event emitter",
   "main": "collection.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test"
+    "test": "./node_modules/mocha/bin/mocha test -t 10000"
   },
   "keywords": [
     "zetta"
@@ -16,8 +16,8 @@
   },
   "devDependencies": {
     "mocha": "^2.4.5",
-    "zetta": "^1.0.0-beta.6",
+    "zetta": "^1.0.0",
     "zetta-cluster": "^6.3.0",
-    "zetta-photocell-mock-driver": "^0.8.0"
+    "zetta-photocell-mock-driver": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
     "zetta"
   ],
   "author": "Adam Magaluk <AdamMagaluk@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "node-uuid": "^1.4.7",
+    "zetta-rels": "^0.5.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Subscribe to all devices streams and pipe to event emitter",
   "main": "collection.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/mocha/bin/mocha test"
   },
   "keywords": [
     "zetta"
@@ -12,7 +12,12 @@
   "author": "Adam Magaluk <AdamMagaluk@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "node-uuid": "^1.4.7",
     "zetta-rels": "^0.5.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5",
+    "zetta": "^1.0.0-beta.6",
+    "zetta-cluster": "^6.3.0",
+    "zetta-photocell-mock-driver": "^0.8.0"
   }
 }

--- a/test/test_collection.js
+++ b/test/test_collection.js
@@ -6,15 +6,16 @@ var Photocell = require('zetta-photocell-mock-driver');
 var StatsCollector = require('../');
 
 describe('StatsCollector', function() {
+  
   it('receives data from devices', function(done) {
     var collector = new StatsCollector();
 
-    cluster = zettacluster({ zetta: zetta })
+    var cluster = zettacluster({ zetta: zetta })
       .server('cloud', [collector.collect()])
       .server('test1', [Photocell], ['cloud']);
 
     cluster.on('ready', function() {
-      collector.on('event', function(msg) {
+      collector.once('event', function(msg) {
         assert(!!msg.data);
         cluster.stop();
         setTimeout(done, 10);
@@ -47,23 +48,21 @@ describe('StatsCollector', function() {
         }, 10);
         return;
       } else if (connectCount === 2) {
-        c1.on('ready', function() {
-          var peer = cloudRuntime.httpServer.peers['test1'];
-          var queryKeys = Object.keys(peer.subscriptions)
+        var peer = cloudRuntime.httpServer.peers['test1'];
+        var queryKeys = Object.keys(peer.subscriptions)
             .filter(function(key) {
-              if (key.slice(0, 5) === 'query') {
+              if (key === '**') {
                 return key;
               }
             });
-          var subscriptionCount = queryKeys.length;
-          assert.equal(subscriptionCount, 1);
+        var subscriptionCount = queryKeys.length;
+        assert.equal(subscriptionCount, 1);
 
-          var queryKey = queryKeys[0];
-          assert.equal(peer.subscriptions[queryKey], 1);
+        var queryKey = queryKeys[0];
+        assert.equal(peer.subscriptions[queryKey], 1);
 
-          c1.stop();
-          setTimeout(done, 10);
-        });
+        c1.stop();
+        setTimeout(done, 10);
       }
     });
 

--- a/test/test_collection.js
+++ b/test/test_collection.js
@@ -1,0 +1,76 @@
+var assert = require('assert');
+var zetta = require('zetta');
+var zettacluster = require('zetta-cluster');
+
+var Photocell = require('zetta-photocell-mock-driver');
+var StatsCollector = require('../');
+
+describe('StatsCollector', function() {
+  it('receives data from devices', function(done) {
+    var collector = new StatsCollector();
+
+    cluster = zettacluster({ zetta: zetta })
+      .server('cloud', [collector.collect()])
+      .server('test1', [Photocell], ['cloud']);
+
+    cluster.on('ready', function() {
+      collector.on('event', function(msg) {
+        assert(!!msg.data);
+        cluster.stop();
+        setTimeout(done, 10);
+      });
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
+  it('only stores one query subscription per stream per peer', function(done) {
+    var collector = new StatsCollector();
+
+    var c1 = zettacluster({ zetta: zetta })
+      .server('cloud', [collector.collect()])
+      .server('test1', [Photocell], ['cloud']);
+
+    var cloudRuntime = c1.servers['cloud'];
+    var test1Runtime = c1.servers['test1'];
+
+    var connectCount = 0;
+    test1Runtime.pubsub.subscribe('_peer/connect', function(ev, msg) {
+      connectCount++;
+      if (connectCount === 1) {
+        setTimeout(function() {
+          msg.peer.ws.close();
+        }, 10);
+        return;
+      } else if (connectCount === 2) {
+        c1.on('ready', function() {
+          var peer = cloudRuntime.httpServer.peers['test1'];
+          var queryKeys = Object.keys(peer.subscriptions)
+            .filter(function(key) {
+              if (key.slice(0, 5) === 'query') {
+                return key;
+              }
+            });
+          var subscriptionCount = queryKeys.length;
+          assert.equal(subscriptionCount, 1);
+
+          var queryKey = queryKeys[0];
+          assert.equal(peer.subscriptions[queryKey], 1);
+
+          c1.stop();
+          setTimeout(done, 10);
+        });
+      }
+    });
+
+    c1.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+});

--- a/test/test_collection.js
+++ b/test/test_collection.js
@@ -16,7 +16,14 @@ describe('StatsCollector', function() {
 
     cluster.on('ready', function() {
       collector.once('event', function(msg) {
-        assert(!!msg.data);
+        assert.equal(msg.name.indexOf('devicedata.'), 0);
+        assert(msg.timestamp);
+        assert(msg.value);
+        assert(msg.tags.hub);
+        assert(msg.tags.device);
+        assert(msg.tags.deviceType);
+        assert(msg.tags.stream);
+        
         cluster.stop();
         setTimeout(done, 10);
       });


### PR DESCRIPTION
Changing collection.js to handle new device streams for known hubs / devices.  Uses PeerSocket's pubsub system directly, not VirtualDevices.

Fixes #1.
